### PR TITLE
Fix GitHub Actions test failures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install uv
         run: pip install uv
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --dev --all-extras
       - name: Run backend tests
         run: uv run pytest tests/
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import reactLogo from './assets/react.svg'
-import viteLogo from '../public/vite.svg'
+import viteLogo from '/vite.svg'
 import './App.css'
 
 function App() {


### PR DESCRIPTION
Backend fixes:
- Add --all-extras flag to uv sync --dev to install optional dependencies
- Fix CLIENT_CACHE_MAX_AGE in .env file (remove comment causing parsing error)
- All backend tests now pass (11/11)

Frontend fixes:
- Revert vite.svg import to absolute path /vite.svg for CI compatibility
- Frontend tests now pass locally

Both backend and frontend tests should now work in GitHub Actions