### PR TITLE
Add Dockerfile.prod for backend production deployment

### DIFF
--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,0 +1,66 @@
+# --------- Builder Stage ---------
+FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim AS builder
+
+# Set environment variables for uv
+ENV UV_COMPILE_BYTECODE=1
+ENV UV_LINK_MODE=copy
+
+WORKDIR /app
+
+# Install dependencies first (for better layer caching)
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project
+
+# Copy the project source code
+COPY . /app
+
+# Install the project in non-editable mode
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --no-editable
+
+# --------- Final Stage ---------
+FROM python:3.11-slim-bookworm
+
+# --- OS security updates ---
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends ca-certificates curl dumb-init \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- Ensure pip/setuptools/wheel are updated ---
+RUN python -m pip install --upgrade \
+    "pip>=24.3" \
+    "wheel>=0.43" \
+    "setuptools>=78.1.1"
+
+# Create a non-root user for security
+RUN groupadd --gid 1001 --system app \
+    && useradd --uid 1001 --system --gid app --shell /bin/bash --create-home app
+
+# Copy the virtual environment from the builder stage
+COPY --from=builder --chown=app:app /app/.venv /app/.venv
+
+# Copy the source code
+COPY --from=builder --chown=app:app /app/src /code/src
+
+# Ensure the virtual environment is in the PATH
+ENV PATH="/app/.venv/bin:$PATH"
+ENV PYTHONPATH="/code/src:$PYTHONPATH"
+
+# Switch to the non-root user
+USER app
+
+# Set the working directory
+WORKDIR /code
+
+# Expose port
+EXPOSE 8000
+
+# Use dumb-init to handle signals properly
+ENTRYPOINT ["dumb-init", "--"]
+
+# Production command with gunicorn
+CMD ["gunicorn", "app.main:app", "-w", "4", "-k", "uvicorn.workers.UvicornWorker", "-b", "0.0.0.0:8000"]


### PR DESCRIPTION
Features:
- Multi-stage build with builder and production stages
- Uses uv for fast Python dependency management
- Optimized for production with gunicorn + uvicorn workers
- Security hardened with non-root user (app:1001)
- Includes dumb-init for proper signal handling
- Copies only necessary files to production stage
- Sets correct PYTHONPATH for module discovery
- Exposes port 8000 for FastAPI application

Build tested successfully - container starts and loads FastAPI app correctly. Redis connection errors are expected without Redis service running.