### PR TITLE
fix: resolve @/lib/utils import issues by updating .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+backend/lib/
 lib64/
 parts/
 sdist/

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { cn } from '../lib/utils';
+
+describe('Utils', () => {
+  describe('cn function', () => {
+    it('should merge class names correctly', () => {
+      const result = cn('class1', 'class2');
+      expect(result).toBe('class1 class2');
+    });
+
+    it('should handle conditional classes', () => {
+      const result = cn('base', true && 'conditional', false && 'hidden');
+      expect(result).toBe('base conditional');
+    });
+
+    it('should handle undefined and null values', () => {
+      const result = cn('base', undefined, null, 'valid');
+      expect(result).toBe('base valid');
+    });
+
+    it('should handle empty strings', () => {
+      const result = cn('base', '', 'valid');
+      expect(result).toBe('base valid');
+    });
+
+    it('should merge Tailwind classes correctly', () => {
+      const result = cn('px-4 py-2', 'bg-blue-500', 'text-white');
+      expect(result).toBe('px-4 py-2 bg-blue-500 text-white');
+    });
+
+    it('should handle conflicting Tailwind classes', () => {
+      const result = cn('px-4', 'px-6');
+      expect(result).toBe('px-6'); // Last one should win
+    });
+  });
+});

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,11 +7,6 @@ import tsconfigPaths from "vite-tsconfig-paths";
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss(), tsconfigPaths()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src/'), // Explicitly define the alias
-    },
-  },
   server: {
     port: 3000,
     host: true,
@@ -19,11 +14,5 @@ export default defineConfig({
   define: {
     // Disable Refine Devtools in development to avoid WebSocket errors
     __REFINE_DEVTOOLS_PORT__: JSON.stringify(null),
-  },
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: ['./src/test/setup.ts'],
-    css: true,
   },
 });

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -6,11 +6,6 @@ import path from 'path';
 
 export default defineConfig({
   plugins: [react(), tailwindcss(), tsconfigPaths()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src/'), // Explicitly define the alias
-    },
-  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
- Change lib/ to backend/lib/ in .gitignore to only ignore backend lib folder
- Allow frontend/src/lib/ to be tracked in repository
- Add frontend/src/lib/utils.ts and utils.test.ts to repository
- Update vite.config.ts and vitest.config.ts configurations

This fixes the GitHub Actions alias resolution issues by ensuring the lib folder and utils.ts file are properly tracked in git.